### PR TITLE
configure.ac: Add subdir-objects to the automake flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 Makefile
 Makefile.in
 aclocal.m4
+ar-lib
 autom4te.cache/
 compile
 config.h

--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,8 @@ dnl Standard C Checks
 dnl
 AC_LANG([C])
 AC_PROG_CC()
+AC_PROG_RANLIB
+AM_PROG_AR
 
 dnl
 dnl Standard Header Checks

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -18,16 +18,20 @@ AM_CPPFLAGS = -Wall -Wextra -pedantic -O2
 
 bin_PROGRAMS = edgar
 
-edgar_SOURCES = \
+noinst_LIBRARIES = libedgar.a
+libedgar_a_SOURCES = \
 	apply.c			apply.h			\
 				const.h			\
 	env.c			env.h			\
 	eval.c			eval.h			\
 	fileio.c		fileio.h		\
 	builtin.c		builtin.h		\
-	main.c						\
 	number.c		number.h		\
 	obj.c			obj.h			\
 	parser.c		parser.h		\
 	repl.c			repl.h			\
 	scanner.c 		scanner.h
+
+edgar_SOURCES = \
+	main.c
+edgar_LDADD = libedgar.a

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -45,18 +45,8 @@ SHELL_TESTS = \
 
 check_PROGRAMS = unittests
 
-unittests_SOURCES = test.h unittests.c \
-	$(top_srcdir)/src/apply.c	$(top_srcdir)/src/apply.h	\
-					$(top_srcdir)/src/const.h	\
-	$(top_srcdir)/src/env.c		$(top_srcdir)/src/env.h		\
-	$(top_srcdir)/src/eval.c	$(top_srcdir)/src/eval.h	\
-	$(top_srcdir)/src/fileio.c	$(top_srcdir)/src/fileio.h	\
-	$(top_srcdir)/src/builtin.c	$(top_srcdir)/src/builtin.h	\
-	$(top_srcdir)/src/number.c	$(top_srcdir)/src/number.h	\
-	$(top_srcdir)/src/obj.c		$(top_srcdir)/src/obj.h		\
-	$(top_srcdir)/src/parser.c	$(top_srcdir)/src/parser.h	\
-	$(top_srcdir)/src/repl.c	$(top_srcdir)/src/repl.h	\
-	$(top_srcdir)/src/scanner.c	$(top_srcdir)/src/scanner.h
+unittests_SOURCES = test.h unittests.c
+unittests_LDADD = $(top_builddir)/src/libedgar.a
 
 TESTS = \
 	$(check_PROGRAMS) \


### PR DESCRIPTION
The unit tests depend on files in another directory, and automake 1.14+
will complain when subdir-objects is not set and such a setup is used.
Combined with -Werror, this leads to autoreconf -i failing with a recent
automake.

Since subdir-objects have no ill side-effects, this patch adds that to
the AM_INIT_AUTOMAKE list of options.

Signed-off-by: Gergely Nagy algernon@balabit.hu
